### PR TITLE
Init script uses a stable view version of the dependencies

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -3,5 +3,5 @@
 # set FCCSWBASEDIR to the directory containing this script
 export FCCSWBASEDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 weekday=`date +%a`
-source /cvmfs/fcc.cern.ch/testing/sw/views/${weekday}/x86_64-slc6-gcc62-opt/setup.sh
+source /cvmfs/fcc.cern.ch/testing/sw/views/stable/x86_64-slc6-gcc62-opt/setup.sh
 


### PR DESCRIPTION
Use a fixed view instead of the latest generated view, since the latter might be unstable.